### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -68,7 +68,7 @@ sync_phases 			KEYWORD2
 microsteps 				KEYWORD2
 interpolate 			KEYWORD2
 double_edge_step 		KEYWORD2
-disable_short_protection KEYWORD2
+disable_short_protection	KEYWORD2
 sg_min 					KEYWORD2
 sg_step_width 			KEYWORD2
 sg_max 					KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords