### PR TITLE
Dereferences the return value of portOutputRegister

### DIFF
--- a/src/source/SW_SPI.cpp
+++ b/src/source/SW_SPI.cpp
@@ -39,9 +39,9 @@ void SW_SPIClass::init() {
     miso_bm = digitalPinToBitMask(miso_pin);
     sck_bm = digitalPinToBitMask(sck_pin);
     #ifdef ARDUINO_ARCH_AVR
-      mosi_register = portOutputRegister(getPort(mosi_pin));
-      miso_register = portOutputRegister(getPort(miso_pin));
-      sck_register = portOutputRegister(getPort(sck_pin));
+      mosi_register = *portOutputRegister(getPort(mosi_pin));
+      miso_register = *portOutputRegister(getPort(miso_pin));
+      sck_register = *portOutputRegister(getPort(sck_pin));
     #endif
   #endif
 }


### PR DESCRIPTION
I haven't tested this on hardware, and I'm not an expert on digital I/O, I just noticed a compile warning:
```
SW_SPI.cpp:43:21: warning: invalid conversion from 'volatile uint8_t* {aka volatile unsigned char*}' to 'uint8_t {aka unsigned char}' [-fpermissive]
       miso_register = portOutputRegister(getPort(miso_pin));
```

The mentioned type conversion is indeed taking place in my build. See documentation for [`portOutputRegister()`](https://garretlab.web.fc2.com/en/arduino/inside/arduino/Arduino.h/portOutputRegister.html).

Comparing to Arduino's source code for [`digitalWrite()`](https://github.com/arduino/Arduino/blob/cc0d3322d1527a76319c01729747d5545128f768/hardware/arduino/avr/cores/arduino/wiring_digital.c#L138), it seems like dereferencing the output of `portOutputRegister()` is what we want to do.

We could also change types of `mosi_register`, `miso_register`, and `sck_register` to `volatile uint8_t*`, and do the dereferencing of them in `writeMOSI_H`, `writeMOSI_L`, `writeSCK_H`, `writeSCK_L`, and `readMISO` instead, I guess.