### PR TITLE
Maybe stick to version 2.2.0?

### DIFF
--- a/src/TMC2130Stepper.h
+++ b/src/TMC2130Stepper.h
@@ -214,6 +214,12 @@ class TMC2130Stepper {
 		void sg_current_decrease(uint8_t value);
 		uint8_t sg_current_decrease();
 
+		// Backward compatibility
+		inline void hysterisis_end(int8_t value) { hysteresis_end(value); }
+		inline int8_t hysterisis_end() { hysteresis_end(); }
+		inline void hysterisis_start(uint8_t value) { hysteresis_start(value); }
+		inline uint8_t hysterisis_start() { hysteresis_start(); }
+
 		// Aliases
 
 		// RW: GCONF

--- a/src/TMC2130Stepper.h
+++ b/src/TMC2130Stepper.h
@@ -4,7 +4,7 @@
 #include <Arduino.h>
 #include <stdint.h>
 
-#define TMC2130STEPPER_VERSION 0x020201 // v2.2.1
+#define TMC2130STEPPER_VERSION 0x020200 // v2.2.0
 const uint32_t TMC2130Stepper_version = TMC2130STEPPER_VERSION;
 
 class TMC2130Stepper {


### PR DESCRIPTION
I bumped the version in case you wanted to hold the change till the next release. But if you're merging now, then might as well keep it at 2.2.0.