### PR TITLE
Prefix macros to avoid name clashing with STM32 Arduino Core

### DIFF
--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -176,88 +176,88 @@ uint8_t TMC2130Stepper::test_connection() {
 // R+C: GSTAT
 void 	TMC2130Stepper::GSTAT(uint8_t input){
 	GSTAT_sr = input;
-	WRITE_REG(GSTAT);
+	TMC_WRITE_REG(GSTAT);
 }
-uint8_t TMC2130Stepper::GSTAT()			 	{ READ_REG_R(GSTAT); 		}
-bool 	TMC2130Stepper::reset()				{ GET_BYTE(GSTAT, RESET);	}
-bool 	TMC2130Stepper::drv_err()			{ GET_BYTE(GSTAT, DRV_ERR);	}
-bool 	TMC2130Stepper::uv_cp()				{ GET_BYTE(GSTAT, UV_CP);	}
+uint8_t TMC2130Stepper::GSTAT()			 	{ TMC_READ_REG_R(GSTAT); 		}
+bool 	TMC2130Stepper::reset()				{ TMC_GET_BYTE(GSTAT, RESET);	}
+bool 	TMC2130Stepper::drv_err()			{ TMC_GET_BYTE(GSTAT, DRV_ERR);	}
+bool 	TMC2130Stepper::uv_cp()				{ TMC_GET_BYTE(GSTAT, UV_CP);	}
 ///////////////////////////////////////////////////////////////////////////////////////
 // R: IOIN
-uint32_t 	TMC2130Stepper::IOIN() 			{ READ_REG_R(IOIN); 				}
-bool 		TMC2130Stepper::step()			{ GET_BYTE_R(IOIN, STEP);			}
-bool 		TMC2130Stepper::dir()			{ GET_BYTE_R(IOIN, DIR);			}
-bool 		TMC2130Stepper::dcen_cfg4()		{ GET_BYTE_R(IOIN, DCEN_CFG4);		}
-bool 		TMC2130Stepper::dcin_cfg5()		{ GET_BYTE_R(IOIN, DCIN_CFG5);		}
-bool 		TMC2130Stepper::drv_enn_cfg6()	{ GET_BYTE_R(IOIN, DRV_ENN_CFG6);	}
-bool 		TMC2130Stepper::dco()			{ GET_BYTE_R(IOIN, DCO);			}
-uint8_t 	TMC2130Stepper::version() 		{ GET_BYTE_R(IOIN, VERSION);		}
+uint32_t 	TMC2130Stepper::IOIN() 			{ TMC_READ_REG_R(IOIN); 				}
+bool 		TMC2130Stepper::step()			{ TMC_GET_BYTE_R(IOIN, STEP);			}
+bool 		TMC2130Stepper::dir()			{ TMC_GET_BYTE_R(IOIN, DIR);			}
+bool 		TMC2130Stepper::dcen_cfg4()		{ TMC_GET_BYTE_R(IOIN, DCEN_CFG4);		}
+bool 		TMC2130Stepper::dcin_cfg5()		{ TMC_GET_BYTE_R(IOIN, DCIN_CFG5);		}
+bool 		TMC2130Stepper::drv_enn_cfg6()	{ TMC_GET_BYTE_R(IOIN, DRV_ENN_CFG6);	}
+bool 		TMC2130Stepper::dco()			{ TMC_GET_BYTE_R(IOIN, DCO);			}
+uint8_t 	TMC2130Stepper::version() 		{ TMC_GET_BYTE_R(IOIN, VERSION);		}
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: TPOWERDOWN
 uint32_t TMC2130Stepper::TPOWERDOWN() { return TPOWERDOWN_sr; }
 void TMC2130Stepper::TPOWERDOWN(uint32_t input) {
 	TPOWERDOWN_sr = input;
-	WRITE_REG(TPOWERDOWN);
+	TMC_WRITE_REG(TPOWERDOWN);
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // R: TSTEP
-uint32_t TMC2130Stepper::TSTEP() { READ_REG_R(TSTEP); }
+uint32_t TMC2130Stepper::TSTEP() { TMC_READ_REG_R(TSTEP); }
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: TPWMTHRS
 uint32_t TMC2130Stepper::TPWMTHRS() { return TPWMTHRS_sr; }
 void TMC2130Stepper::TPWMTHRS(uint32_t input) {
 	TPWMTHRS_sr = input;
-	WRITE_REG(TPWMTHRS);
+	TMC_WRITE_REG(TPWMTHRS);
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: TCOOLTHRS
 uint32_t TMC2130Stepper::TCOOLTHRS() { return TCOOLTHRS_sr; }
 void TMC2130Stepper::TCOOLTHRS(uint32_t input) {
 	TCOOLTHRS_sr = input;
-	WRITE_REG(TCOOLTHRS);
+	TMC_WRITE_REG(TCOOLTHRS);
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: THIGH
 uint32_t TMC2130Stepper::THIGH() { return THIGH_sr; }
 void TMC2130Stepper::THIGH(uint32_t input) {
 	THIGH_sr = input;
-	WRITE_REG(THIGH);
+	TMC_WRITE_REG(THIGH);
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // RW: XDIRECT
-uint32_t TMC2130Stepper::XDIRECT() { READ_REG(XDIRECT); }
+uint32_t TMC2130Stepper::XDIRECT() { TMC_READ_REG(XDIRECT); }
 void TMC2130Stepper::XDIRECT(uint32_t input) {
 	XDIRECT_sr = input;
-	WRITE_REG(XDIRECT);
+	TMC_WRITE_REG(XDIRECT);
 }
-void TMC2130Stepper::coil_A(int16_t B) 	{ MOD_REG(XDIRECT, COIL_A); 	}
-void TMC2130Stepper::coil_B(int16_t B) 	{ MOD_REG(XDIRECT, COIL_B); 	}
-int16_t TMC2130Stepper::coil_A() 		{ GET_BYTE_R(XDIRECT, COIL_A); 	}
-int16_t TMC2130Stepper::coil_B() 		{ GET_BYTE_R(XDIRECT, COIL_A); 	}
+void TMC2130Stepper::coil_A(int16_t B) 	{ TMC_MOD_REG(XDIRECT, COIL_A); 	}
+void TMC2130Stepper::coil_B(int16_t B) 	{ TMC_MOD_REG(XDIRECT, COIL_B); 	}
+int16_t TMC2130Stepper::coil_A() 		{ TMC_GET_BYTE_R(XDIRECT, COIL_A); 	}
+int16_t TMC2130Stepper::coil_B() 		{ TMC_GET_BYTE_R(XDIRECT, COIL_A); 	}
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: VDCMIN
 uint32_t TMC2130Stepper::VDCMIN() { return VDCMIN_sr; }
 void TMC2130Stepper::VDCMIN(uint32_t input) {
 	VDCMIN_sr = input;
-	WRITE_REG(VDCMIN);
+	TMC_WRITE_REG(VDCMIN);
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // R: PWM_SCALE
-uint8_t TMC2130Stepper::PWM_SCALE() { READ_REG_R(PWM_SCALE); }
+uint8_t TMC2130Stepper::PWM_SCALE() { TMC_READ_REG_R(PWM_SCALE); }
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: ENCM_CTRL
 uint8_t TMC2130Stepper::ENCM_CTRL() { return ENCM_CTRL_sr; }
 void TMC2130Stepper::ENCM_CTRL(uint8_t input) {
 	ENCM_CTRL_sr = input;
-	WRITE_REG(ENCM_CTRL);
+	TMC_WRITE_REG(ENCM_CTRL);
 }
-void TMC2130Stepper::inv(bool B)		{ MOD_REG(ENCM_CTRL, INV);		}
-void TMC2130Stepper::maxspeed(bool B)	{ MOD_REG(ENCM_CTRL, MAXSPEED); }
-bool TMC2130Stepper::inv() 				{ GET_BYTE(ENCM_CTRL, INV); 	}
-bool TMC2130Stepper::maxspeed() 		{ GET_BYTE(ENCM_CTRL, MAXSPEED);}
+void TMC2130Stepper::inv(bool B)		{ TMC_MOD_REG(ENCM_CTRL, INV);		}
+void TMC2130Stepper::maxspeed(bool B)	{ TMC_MOD_REG(ENCM_CTRL, MAXSPEED); }
+bool TMC2130Stepper::inv() 				{ TMC_GET_BYTE(ENCM_CTRL, INV); 	}
+bool TMC2130Stepper::maxspeed() 		{ TMC_GET_BYTE(ENCM_CTRL, MAXSPEED);}
 ///////////////////////////////////////////////////////////////////////////////////////
 // R: LOST_STEPS
-uint32_t TMC2130Stepper::LOST_STEPS() { READ_REG_R(LOST_STEPS); }
+uint32_t TMC2130Stepper::LOST_STEPS() { TMC_READ_REG_R(LOST_STEPS); }
 
 
 /**

--- a/src/source/TMC2130Stepper_CHOPCONF.cpp
+++ b/src/source/TMC2130Stepper_CHOPCONF.cpp
@@ -2,45 +2,45 @@
 #include "TMC2130Stepper_MACROS.h"
 
 // CHOPCONF
-uint32_t TMC2130Stepper::CHOPCONF() { READ_REG(CHOPCONF); }
+uint32_t TMC2130Stepper::CHOPCONF() { TMC_READ_REG(CHOPCONF); }
 void TMC2130Stepper::CHOPCONF(uint32_t input) {
 	CHOPCONF_sr = input;
-	WRITE_REG(CHOPCONF);
+	TMC_WRITE_REG(CHOPCONF);
 }
 
-void TMC2130Stepper::toff(		uint8_t B )	{ MOD_REG(CHOPCONF, TOFF);		}
-void TMC2130Stepper::hstrt(		uint8_t B )	{ MOD_REG(CHOPCONF, HSTRT);		}
-void TMC2130Stepper::hend(		int8_t  B )	{ MOD_REG(CHOPCONF, HEND);		}
-void TMC2130Stepper::fd(		uint8_t B )	{ MOD_REG(CHOPCONF, FD);		}
-void TMC2130Stepper::disfdcc(	bool 	B )	{ MOD_REG(CHOPCONF, DISFDCC);	}
-void TMC2130Stepper::rndtf(		bool 	B )	{ MOD_REG(CHOPCONF, RNDTF);		}
-void TMC2130Stepper::chm(		bool 	B )	{ MOD_REG(CHOPCONF, CHM);		}
-void TMC2130Stepper::tbl(		uint8_t B )	{ MOD_REG(CHOPCONF, TBL);		}
-void TMC2130Stepper::vsense(	bool 	B )	{ MOD_REG(CHOPCONF, VSENSE);	}
-void TMC2130Stepper::vhighfs(	bool 	B )	{ MOD_REG(CHOPCONF, VHIGHFS);	}
-void TMC2130Stepper::vhighchm(	bool 	B )	{ MOD_REG(CHOPCONF, VHIGHCHM);	}
-void TMC2130Stepper::sync(		uint8_t B )	{ MOD_REG(CHOPCONF, SYNC);		}
-void TMC2130Stepper::mres(		uint8_t B )	{ MOD_REG(CHOPCONF, MRES);		}
-void TMC2130Stepper::intpol(	bool 	B )	{ MOD_REG(CHOPCONF, INTPOL);	}
-void TMC2130Stepper::dedge(		bool 	B )	{ MOD_REG(CHOPCONF, DEDGE);		}
-void TMC2130Stepper::diss2g(	bool 	B )	{ MOD_REG(CHOPCONF, DISS2G);	}
+void TMC2130Stepper::toff(		uint8_t B )	{ TMC_MOD_REG(CHOPCONF, TOFF);		}
+void TMC2130Stepper::hstrt(		uint8_t B )	{ TMC_MOD_REG(CHOPCONF, HSTRT);		}
+void TMC2130Stepper::hend(		int8_t  B )	{ TMC_MOD_REG(CHOPCONF, HEND);		}
+void TMC2130Stepper::fd(		uint8_t B )	{ TMC_MOD_REG(CHOPCONF, FD);		}
+void TMC2130Stepper::disfdcc(	bool 	B )	{ TMC_MOD_REG(CHOPCONF, DISFDCC);	}
+void TMC2130Stepper::rndtf(		bool 	B )	{ TMC_MOD_REG(CHOPCONF, RNDTF);		}
+void TMC2130Stepper::chm(		bool 	B )	{ TMC_MOD_REG(CHOPCONF, CHM);		}
+void TMC2130Stepper::tbl(		uint8_t B )	{ TMC_MOD_REG(CHOPCONF, TBL);		}
+void TMC2130Stepper::vsense(	bool 	B )	{ TMC_MOD_REG(CHOPCONF, VSENSE);	}
+void TMC2130Stepper::vhighfs(	bool 	B )	{ TMC_MOD_REG(CHOPCONF, VHIGHFS);	}
+void TMC2130Stepper::vhighchm(	bool 	B )	{ TMC_MOD_REG(CHOPCONF, VHIGHCHM);	}
+void TMC2130Stepper::sync(		uint8_t B )	{ TMC_MOD_REG(CHOPCONF, SYNC);		}
+void TMC2130Stepper::mres(		uint8_t B )	{ TMC_MOD_REG(CHOPCONF, MRES);		}
+void TMC2130Stepper::intpol(	bool 	B )	{ TMC_MOD_REG(CHOPCONF, INTPOL);	}
+void TMC2130Stepper::dedge(		bool 	B )	{ TMC_MOD_REG(CHOPCONF, DEDGE);		}
+void TMC2130Stepper::diss2g(	bool 	B )	{ TMC_MOD_REG(CHOPCONF, DISS2G);	}
 
-uint8_t TMC2130Stepper::toff()		{ GET_BYTE(CHOPCONF, TOFF);		}
-uint8_t TMC2130Stepper::hstrt()		{ GET_BYTE(CHOPCONF, HSTRT);	}
-int8_t  TMC2130Stepper::hend()		{ GET_BYTE(CHOPCONF, HEND);		}
-uint8_t TMC2130Stepper::fd()		{ GET_BYTE(CHOPCONF, FD);		}
-bool 	TMC2130Stepper::disfdcc()	{ GET_BYTE(CHOPCONF, DISFDCC);	}
-bool 	TMC2130Stepper::rndtf()		{ GET_BYTE(CHOPCONF, RNDTF);	}
-bool 	TMC2130Stepper::chm()		{ GET_BYTE(CHOPCONF, CHM);		}
-uint8_t TMC2130Stepper::tbl()		{ GET_BYTE(CHOPCONF, TBL);		}
-bool 	TMC2130Stepper::vsense()	{ GET_BIT( CHOPCONF, VSENSE);	}
-bool 	TMC2130Stepper::vhighfs()	{ GET_BYTE(CHOPCONF, VHIGHFS);	}
-bool 	TMC2130Stepper::vhighchm()	{ GET_BYTE(CHOPCONF, VHIGHCHM);	}
-uint8_t TMC2130Stepper::sync()		{ GET_BYTE(CHOPCONF, SYNC);		}
-uint8_t TMC2130Stepper::mres()		{ GET_BYTE(CHOPCONF, MRES);		}
-bool 	TMC2130Stepper::intpol()	{ GET_BYTE(CHOPCONF, INTPOL);	}
-bool 	TMC2130Stepper::dedge()		{ GET_BYTE(CHOPCONF, DEDGE);	}
-bool 	TMC2130Stepper::diss2g()	{ GET_BYTE(CHOPCONF, DISS2G);	}
+uint8_t TMC2130Stepper::toff()		{ TMC_GET_BYTE(CHOPCONF, TOFF);		}
+uint8_t TMC2130Stepper::hstrt()		{ TMC_GET_BYTE(CHOPCONF, HSTRT);	}
+int8_t  TMC2130Stepper::hend()		{ TMC_GET_BYTE(CHOPCONF, HEND);		}
+uint8_t TMC2130Stepper::fd()		{ TMC_GET_BYTE(CHOPCONF, FD);		}
+bool 	TMC2130Stepper::disfdcc()	{ TMC_GET_BYTE(CHOPCONF, DISFDCC);	}
+bool 	TMC2130Stepper::rndtf()		{ TMC_GET_BYTE(CHOPCONF, RNDTF);	}
+bool 	TMC2130Stepper::chm()		{ TMC_GET_BYTE(CHOPCONF, CHM);		}
+uint8_t TMC2130Stepper::tbl()		{ TMC_GET_BYTE(CHOPCONF, TBL);		}
+bool 	TMC2130Stepper::vsense()	{ TMC_GET_BIT( CHOPCONF, VSENSE);	}
+bool 	TMC2130Stepper::vhighfs()	{ TMC_GET_BYTE(CHOPCONF, VHIGHFS);	}
+bool 	TMC2130Stepper::vhighchm()	{ TMC_GET_BYTE(CHOPCONF, VHIGHCHM);	}
+uint8_t TMC2130Stepper::sync()		{ TMC_GET_BYTE(CHOPCONF, SYNC);		}
+uint8_t TMC2130Stepper::mres()		{ TMC_GET_BYTE(CHOPCONF, MRES);		}
+bool 	TMC2130Stepper::intpol()	{ TMC_GET_BYTE(CHOPCONF, INTPOL);	}
+bool 	TMC2130Stepper::dedge()		{ TMC_GET_BYTE(CHOPCONF, DEDGE);	}
+bool 	TMC2130Stepper::diss2g()	{ TMC_GET_BYTE(CHOPCONF, DISS2G);	}
 
 void TMC2130Stepper::hysteresis_end(int8_t value) { hend(value+3); }
 int8_t TMC2130Stepper::hysteresis_end() { return hend()-3; };

--- a/src/source/TMC2130Stepper_COOLCONF.cpp
+++ b/src/source/TMC2130Stepper_COOLCONF.cpp
@@ -5,24 +5,24 @@
 uint32_t TMC2130Stepper::COOLCONF() { return COOLCONF_sr; }
 void TMC2130Stepper::COOLCONF(uint32_t input) {
 	COOLCONF_sr = input;
-	WRITE_REG(COOLCONF);
+	TMC_WRITE_REG(COOLCONF);
 }
 
-void TMC2130Stepper::semin(		uint8_t B )	{ MOD_REG(COOLCONF, SEMIN);		}
-void TMC2130Stepper::seup(		uint8_t B )	{ MOD_REG(COOLCONF, SEUP);		}
-void TMC2130Stepper::semax(		uint8_t B )	{ MOD_REG(COOLCONF, SEMAX);		}
-void TMC2130Stepper::sedn(		uint8_t B )	{ MOD_REG(COOLCONF, SEDN);		}
-void TMC2130Stepper::seimin(	bool 	B )	{ MOD_REG(COOLCONF, SEIMIN);	}
-void TMC2130Stepper::sgt(		int8_t  B )	{ MOD_REG(COOLCONF, SGT);		}
-void TMC2130Stepper::sfilt(		bool 	B )	{ MOD_REG(COOLCONF, SFILT);		}
+void TMC2130Stepper::semin(		uint8_t B )	{ TMC_MOD_REG(COOLCONF, SEMIN);		}
+void TMC2130Stepper::seup(		uint8_t B )	{ TMC_MOD_REG(COOLCONF, SEUP);		}
+void TMC2130Stepper::semax(		uint8_t B )	{ TMC_MOD_REG(COOLCONF, SEMAX);		}
+void TMC2130Stepper::sedn(		uint8_t B )	{ TMC_MOD_REG(COOLCONF, SEDN);		}
+void TMC2130Stepper::seimin(	bool 	B )	{ TMC_MOD_REG(COOLCONF, SEIMIN);	}
+void TMC2130Stepper::sgt(		int8_t  B )	{ TMC_MOD_REG(COOLCONF, SGT);		}
+void TMC2130Stepper::sfilt(		bool 	B )	{ TMC_MOD_REG(COOLCONF, SFILT);		}
 
-uint8_t TMC2130Stepper::semin()	{ GET_BYTE(COOLCONF, SEMIN);	}
-uint8_t TMC2130Stepper::seup()	{ GET_BYTE(COOLCONF, SEUP);		}
-uint8_t TMC2130Stepper::semax()	{ GET_BYTE(COOLCONF, SEMAX);	}
-uint8_t TMC2130Stepper::sedn()	{ GET_BYTE(COOLCONF, SEDN);		}
-bool TMC2130Stepper::seimin()	{ GET_BYTE(COOLCONF, SEIMIN);	}
-//int8_t TMC2130Stepper::sgt()	{ GET_BYTE(COOLCONF, SGT);		}
-bool TMC2130Stepper::sfilt()	{ GET_BYTE(COOLCONF, SFILT);	}
+uint8_t TMC2130Stepper::semin()	{ TMC_GET_BYTE(COOLCONF, SEMIN);	}
+uint8_t TMC2130Stepper::seup()	{ TMC_GET_BYTE(COOLCONF, SEUP);		}
+uint8_t TMC2130Stepper::semax()	{ TMC_GET_BYTE(COOLCONF, SEMAX);	}
+uint8_t TMC2130Stepper::sedn()	{ TMC_GET_BYTE(COOLCONF, SEDN);		}
+bool TMC2130Stepper::seimin()	{ TMC_GET_BYTE(COOLCONF, SEIMIN);	}
+//int8_t TMC2130Stepper::sgt()	{ TMC_GET_BYTE(COOLCONF, SGT);		}
+bool TMC2130Stepper::sfilt()	{ TMC_GET_BYTE(COOLCONF, SFILT);	}
 
 int8_t TMC2130Stepper::sgt() {
 	// Two's complement in a 7bit value

--- a/src/source/TMC2130Stepper_DRV_STATUS.cpp
+++ b/src/source/TMC2130Stepper_DRV_STATUS.cpp
@@ -1,19 +1,19 @@
 #include "TMC2130Stepper.h"
 #include "TMC2130Stepper_MACROS.h"
 
-uint32_t TMC2130Stepper::DRV_STATUS() { READ_REG_R(DRV_STATUS); }
+uint32_t TMC2130Stepper::DRV_STATUS() { TMC_READ_REG_R(DRV_STATUS); }
 
-uint16_t TMC2130Stepper::sg_result(){ GET_BYTE_R(DRV_STATUS, SG_RESULT); 	}
-bool TMC2130Stepper::fsactive()		{ GET_BYTE_R(DRV_STATUS, FSACTIVE); 	}
-uint8_t TMC2130Stepper::cs_actual()	{ GET_BYTE_R(DRV_STATUS, CS_ACTUAL); 	}
-bool TMC2130Stepper::stallguard()	{ GET_BYTE_R(DRV_STATUS, STALLGUARD); 	}
-bool TMC2130Stepper::ot()			{ GET_BYTE_R(DRV_STATUS, OT); 			}
-bool TMC2130Stepper::otpw()			{ GET_BYTE_R(DRV_STATUS, OTPW); 		}
-bool TMC2130Stepper::s2ga()			{ GET_BYTE_R(DRV_STATUS, S2GA); 		}
-bool TMC2130Stepper::s2gb()			{ GET_BYTE_R(DRV_STATUS, S2GB); 		}
-bool TMC2130Stepper::ola()			{ GET_BYTE_R(DRV_STATUS, OLA); 			}
-bool TMC2130Stepper::olb()			{ GET_BYTE_R(DRV_STATUS, OLB); 			}
-bool TMC2130Stepper::stst()			{ GET_BYTE_R(DRV_STATUS, STST); 		}
+uint16_t TMC2130Stepper::sg_result(){ TMC_GET_BYTE_R(DRV_STATUS, SG_RESULT); 	}
+bool TMC2130Stepper::fsactive()		{ TMC_GET_BYTE_R(DRV_STATUS, FSACTIVE); 	}
+uint8_t TMC2130Stepper::cs_actual()	{ TMC_GET_BYTE_R(DRV_STATUS, CS_ACTUAL); 	}
+bool TMC2130Stepper::stallguard()	{ TMC_GET_BYTE_R(DRV_STATUS, STALLGUARD); 	}
+bool TMC2130Stepper::ot()			{ TMC_GET_BYTE_R(DRV_STATUS, OT); 			}
+bool TMC2130Stepper::otpw()			{ TMC_GET_BYTE_R(DRV_STATUS, OTPW); 		}
+bool TMC2130Stepper::s2ga()			{ TMC_GET_BYTE_R(DRV_STATUS, S2GA); 		}
+bool TMC2130Stepper::s2gb()			{ TMC_GET_BYTE_R(DRV_STATUS, S2GB); 		}
+bool TMC2130Stepper::ola()			{ TMC_GET_BYTE_R(DRV_STATUS, OLA); 			}
+bool TMC2130Stepper::olb()			{ TMC_GET_BYTE_R(DRV_STATUS, OLB); 			}
+bool TMC2130Stepper::stst()			{ TMC_GET_BYTE_R(DRV_STATUS, STST); 		}
 /*
 uint16_t TMC2130Stepper::sg_result()	{
 	uint32_t drv_status = 0x00000000UL;

--- a/src/source/TMC2130Stepper_GCONF.cpp
+++ b/src/source/TMC2130Stepper_GCONF.cpp
@@ -2,47 +2,47 @@
 #include "TMC2130Stepper_MACROS.h"
 
 // GCONF
-uint32_t TMC2130Stepper::GCONF() { READ_REG(GCONF); }
+uint32_t TMC2130Stepper::GCONF() { TMC_READ_REG(GCONF); }
 void TMC2130Stepper::GCONF(uint32_t input) {
 	GCONF_sr = input;
-	WRITE_REG(GCONF);
+	TMC_WRITE_REG(GCONF);
 }
 
-void TMC2130Stepper::I_scale_analog(bool B)			{ MOD_REG(GCONF, I_SCALE_ANALOG);		}
-void TMC2130Stepper::internal_Rsense(bool B)		{ MOD_REG(GCONF, INTERNAL_RSENSE);		}
-void TMC2130Stepper::en_pwm_mode(bool B)			{ MOD_REG(GCONF, EN_PWM_MODE);			}
-void TMC2130Stepper::enc_commutation(bool B)		{ MOD_REG(GCONF, ENC_COMMUTATION);		}
-void TMC2130Stepper::shaft(bool B) 					{ MOD_REG(GCONF, SHAFT);				}
-void TMC2130Stepper::diag0_error(bool B) 			{ MOD_REG(GCONF, DIAG0_ERROR);			}
-void TMC2130Stepper::diag0_otpw(bool B) 			{ MOD_REG(GCONF, DIAG0_OTPW);			}
-void TMC2130Stepper::diag0_stall(bool B) 			{ MOD_REG(GCONF, DIAG0_STALL);			}
-void TMC2130Stepper::diag1_stall(bool B) 			{ MOD_REG(GCONF, DIAG1_STALL);			}
-void TMC2130Stepper::diag1_index(bool B) 			{ MOD_REG(GCONF, DIAG1_INDEX);			}
-void TMC2130Stepper::diag1_onstate(bool B) 			{ MOD_REG(GCONF, DIAG1_ONSTATE);		}
-void TMC2130Stepper::diag1_steps_skipped(bool B) 	{ MOD_REG(GCONF, DIAG1_STEPS_SKIPPED);	}
-void TMC2130Stepper::diag0_int_pushpull(bool B) 	{ MOD_REG(GCONF, DIAG0_INT_PUSHPULL);	}
-void TMC2130Stepper::diag1_pushpull(bool B) 		{ MOD_REG(GCONF, DIAG1_PUSHPULL);		}
-void TMC2130Stepper::small_hysteresis(bool B) 		{ MOD_REG(GCONF, SMALL_HYSTERESIS);		}
-void TMC2130Stepper::stop_enable(bool B) 			{ MOD_REG(GCONF, STOP_ENABLE);			}
-void TMC2130Stepper::direct_mode(bool B) 			{ MOD_REG(GCONF, DIRECT_MODE);			}
+void TMC2130Stepper::I_scale_analog(bool B)			{ TMC_MOD_REG(GCONF, I_SCALE_ANALOG);		}
+void TMC2130Stepper::internal_Rsense(bool B)		{ TMC_MOD_REG(GCONF, INTERNAL_RSENSE);		}
+void TMC2130Stepper::en_pwm_mode(bool B)			{ TMC_MOD_REG(GCONF, EN_PWM_MODE);			}
+void TMC2130Stepper::enc_commutation(bool B)		{ TMC_MOD_REG(GCONF, ENC_COMMUTATION);		}
+void TMC2130Stepper::shaft(bool B) 					{ TMC_MOD_REG(GCONF, SHAFT);				}
+void TMC2130Stepper::diag0_error(bool B) 			{ TMC_MOD_REG(GCONF, DIAG0_ERROR);			}
+void TMC2130Stepper::diag0_otpw(bool B) 			{ TMC_MOD_REG(GCONF, DIAG0_OTPW);			}
+void TMC2130Stepper::diag0_stall(bool B) 			{ TMC_MOD_REG(GCONF, DIAG0_STALL);			}
+void TMC2130Stepper::diag1_stall(bool B) 			{ TMC_MOD_REG(GCONF, DIAG1_STALL);			}
+void TMC2130Stepper::diag1_index(bool B) 			{ TMC_MOD_REG(GCONF, DIAG1_INDEX);			}
+void TMC2130Stepper::diag1_onstate(bool B) 			{ TMC_MOD_REG(GCONF, DIAG1_ONSTATE);		}
+void TMC2130Stepper::diag1_steps_skipped(bool B) 	{ TMC_MOD_REG(GCONF, DIAG1_STEPS_SKIPPED);	}
+void TMC2130Stepper::diag0_int_pushpull(bool B) 	{ TMC_MOD_REG(GCONF, DIAG0_INT_PUSHPULL);	}
+void TMC2130Stepper::diag1_pushpull(bool B) 		{ TMC_MOD_REG(GCONF, DIAG1_PUSHPULL);		}
+void TMC2130Stepper::small_hysteresis(bool B) 		{ TMC_MOD_REG(GCONF, SMALL_HYSTERESIS);		}
+void TMC2130Stepper::stop_enable(bool B) 			{ TMC_MOD_REG(GCONF, STOP_ENABLE);			}
+void TMC2130Stepper::direct_mode(bool B) 			{ TMC_MOD_REG(GCONF, DIRECT_MODE);			}
 
-bool TMC2130Stepper::I_scale_analog()				{ GET_BYTE(GCONF, I_SCALE_ANALOG);		}
-bool TMC2130Stepper::internal_Rsense()				{ GET_BYTE(GCONF, INTERNAL_RSENSE);		}
-bool TMC2130Stepper::en_pwm_mode()					{ GET_BYTE(GCONF, EN_PWM_MODE);			}
-bool TMC2130Stepper::enc_commutation()				{ GET_BYTE(GCONF, ENC_COMMUTATION);		}
-bool TMC2130Stepper::shaft() 						{ GET_BYTE(GCONF, SHAFT);				}
-bool TMC2130Stepper::diag0_error() 					{ GET_BYTE(GCONF, DIAG0_ERROR);			}
-bool TMC2130Stepper::diag0_otpw() 					{ GET_BYTE(GCONF, DIAG0_OTPW);			}
-bool TMC2130Stepper::diag0_stall() 					{ GET_BYTE(GCONF, DIAG0_STALL);			}
-bool TMC2130Stepper::diag1_stall() 					{ GET_BYTE(GCONF, DIAG1_STALL);			}
-bool TMC2130Stepper::diag1_index() 					{ GET_BYTE(GCONF, DIAG1_INDEX);			}
-bool TMC2130Stepper::diag1_onstate() 				{ GET_BYTE(GCONF, DIAG1_ONSTATE);		}
-bool TMC2130Stepper::diag1_steps_skipped() 			{ GET_BYTE(GCONF, DIAG1_STEPS_SKIPPED);	}
-bool TMC2130Stepper::diag0_int_pushpull() 			{ GET_BYTE(GCONF, DIAG0_INT_PUSHPULL);	}
-bool TMC2130Stepper::diag1_pushpull() 				{ GET_BYTE(GCONF, DIAG1_PUSHPULL);		}
-bool TMC2130Stepper::small_hysteresis() 			{ GET_BYTE(GCONF, SMALL_HYSTERESIS);	}
-bool TMC2130Stepper::stop_enable() 					{ GET_BYTE(GCONF, STOP_ENABLE);			}
-bool TMC2130Stepper::direct_mode() 					{ GET_BYTE(GCONF, DIRECT_MODE);			}
+bool TMC2130Stepper::I_scale_analog()				{ TMC_GET_BYTE(GCONF, I_SCALE_ANALOG);		}
+bool TMC2130Stepper::internal_Rsense()				{ TMC_GET_BYTE(GCONF, INTERNAL_RSENSE);		}
+bool TMC2130Stepper::en_pwm_mode()					{ TMC_GET_BYTE(GCONF, EN_PWM_MODE);			}
+bool TMC2130Stepper::enc_commutation()				{ TMC_GET_BYTE(GCONF, ENC_COMMUTATION);		}
+bool TMC2130Stepper::shaft() 						{ TMC_GET_BYTE(GCONF, SHAFT);				}
+bool TMC2130Stepper::diag0_error() 					{ TMC_GET_BYTE(GCONF, DIAG0_ERROR);			}
+bool TMC2130Stepper::diag0_otpw() 					{ TMC_GET_BYTE(GCONF, DIAG0_OTPW);			}
+bool TMC2130Stepper::diag0_stall() 					{ TMC_GET_BYTE(GCONF, DIAG0_STALL);			}
+bool TMC2130Stepper::diag1_stall() 					{ TMC_GET_BYTE(GCONF, DIAG1_STALL);			}
+bool TMC2130Stepper::diag1_index() 					{ TMC_GET_BYTE(GCONF, DIAG1_INDEX);			}
+bool TMC2130Stepper::diag1_onstate() 				{ TMC_GET_BYTE(GCONF, DIAG1_ONSTATE);		}
+bool TMC2130Stepper::diag1_steps_skipped() 			{ TMC_GET_BYTE(GCONF, DIAG1_STEPS_SKIPPED);	}
+bool TMC2130Stepper::diag0_int_pushpull() 			{ TMC_GET_BYTE(GCONF, DIAG0_INT_PUSHPULL);	}
+bool TMC2130Stepper::diag1_pushpull() 				{ TMC_GET_BYTE(GCONF, DIAG1_PUSHPULL);		}
+bool TMC2130Stepper::small_hysteresis() 			{ TMC_GET_BYTE(GCONF, SMALL_HYSTERESIS);	}
+bool TMC2130Stepper::stop_enable() 					{ TMC_GET_BYTE(GCONF, STOP_ENABLE);			}
+bool TMC2130Stepper::direct_mode() 					{ TMC_GET_BYTE(GCONF, DIRECT_MODE);			}
 
 /*
 bit 18 not implemented:

--- a/src/source/TMC2130Stepper_IHOLD_IRUN.cpp
+++ b/src/source/TMC2130Stepper_IHOLD_IRUN.cpp
@@ -4,13 +4,13 @@
 // IHOLD_IRUN
 void TMC2130Stepper::IHOLD_IRUN(uint32_t input) {
 	IHOLD_IRUN_sr = input;
-	WRITE_REG(IHOLD_IRUN);
+	TMC_WRITE_REG(IHOLD_IRUN);
 }
 uint32_t TMC2130Stepper::IHOLD_IRUN() { return IHOLD_IRUN_sr; }
 
-void 	TMC2130Stepper::ihold(uint8_t B) 		{ MOD_REG(IHOLD_IRUN, IHOLD);		}
-void 	TMC2130Stepper::irun(uint8_t B)  		{ MOD_REG(IHOLD_IRUN, IRUN); 		}
-void 	TMC2130Stepper::iholddelay(uint8_t B)	{ MOD_REG(IHOLD_IRUN, IHOLDDELAY); 	}
-uint8_t TMC2130Stepper::ihold() 				{ GET_BYTE(IHOLD_IRUN, IHOLD);		}
-uint8_t TMC2130Stepper::irun()  				{ GET_BYTE(IHOLD_IRUN, IRUN); 		}
-uint8_t TMC2130Stepper::iholddelay()  			{ GET_BYTE(IHOLD_IRUN, IHOLDDELAY);	}
+void 	TMC2130Stepper::ihold(uint8_t B) 		{ TMC_MOD_REG(IHOLD_IRUN, IHOLD);		}
+void 	TMC2130Stepper::irun(uint8_t B)  		{ TMC_MOD_REG(IHOLD_IRUN, IRUN); 		}
+void 	TMC2130Stepper::iholddelay(uint8_t B)	{ TMC_MOD_REG(IHOLD_IRUN, IHOLDDELAY); 	}
+uint8_t TMC2130Stepper::ihold() 				{ TMC_GET_BYTE(IHOLD_IRUN, IHOLD);		}
+uint8_t TMC2130Stepper::irun()  				{ TMC_GET_BYTE(IHOLD_IRUN, IRUN); 		}
+uint8_t TMC2130Stepper::iholddelay()  			{ TMC_GET_BYTE(IHOLD_IRUN, IHOLDDELAY);	}

--- a/src/source/TMC2130Stepper_MACROS.h
+++ b/src/source/TMC2130Stepper_MACROS.h
@@ -3,20 +3,20 @@
 #include "TMC2130Stepper.h"
 #include "../TMC2130Stepper_REGDEFS.h"
 
-#define WRITE_REG(R) 	send2130(TMC2130_WRITE|REG_##R, &R##_sr);
+#define TMC_WRITE_REG(R) 	send2130(TMC2130_WRITE|REG_##R, &R##_sr);
 
-#define READ_REG(R)   	send2130(TMC2130_READ|REG_##R, &R##_sr); return R##_sr
+#define TMC_READ_REG(R)   	send2130(TMC2130_READ|REG_##R, &R##_sr); return R##_sr
 
-#define READ_REG_R(R)   tmp_sr=0; send2130(TMC2130_READ|REG_##R, &tmp_sr); return tmp_sr;
+#define TMC_READ_REG_R(R)   tmp_sr=0; send2130(TMC2130_READ|REG_##R, &tmp_sr); return tmp_sr;
 
-#define MOD_REG(REG, SETTING) 	REG##_sr &= ~SETTING##_bm; \
+#define TMC_MOD_REG(REG, SETTING) 	REG##_sr &= ~SETTING##_bm; \
 								REG##_sr |= ((uint32_t)B<<SETTING##_bp)&SETTING##_bm; \
-								WRITE_REG(REG);
+								TMC_WRITE_REG(REG);
 
-#define GET_BYTE(REG, SETTING) 	return (REG()&SETTING##_bm) >> SETTING##_bp;
+#define TMC_GET_BYTE(REG, SETTING) 	return (REG()&SETTING##_bm) >> SETTING##_bp;
 
-#define GET_BYTE_R(REG, SETTING) return (REG()&SETTING##_bm) >> SETTING##_bp;
+#define TMC_GET_BYTE_R(REG, SETTING) return (REG()&SETTING##_bm) >> SETTING##_bp;
 
-#define GET_BIT(REG, SETTING) 	return (bool)((REG()&SETTING##_bm) >> SETTING##_bp);
+#define TMC_GET_BIT(REG, SETTING) 	return (bool)((REG()&SETTING##_bm) >> SETTING##_bp);
 
 #endif

--- a/src/source/TMC2130Stepper_PWMCONF.cpp
+++ b/src/source/TMC2130Stepper_PWMCONF.cpp
@@ -6,19 +6,19 @@
 uint32_t TMC2130Stepper::PWMCONF() { return PWMCONF_sr; }
 void TMC2130Stepper::PWMCONF(uint32_t input) {
 	PWMCONF_sr = input;
-	WRITE_REG(PWMCONF);
+	TMC_WRITE_REG(PWMCONF);
 }
 
-void TMC2130Stepper::pwm_ampl(		uint8_t B )	{ MOD_REG(PWMCONF, PWM_AMPL);		}
-void TMC2130Stepper::pwm_grad(		uint8_t B )	{ MOD_REG(PWMCONF, PWM_GRAD);		}
-void TMC2130Stepper::pwm_freq(		uint8_t B )	{ MOD_REG(PWMCONF, PWM_FREQ);		}
-void TMC2130Stepper::pwm_autoscale(	bool 	B )	{ MOD_REG(PWMCONF, PWM_AUTOSCALE);	}
-void TMC2130Stepper::pwm_symmetric(	bool 	B )	{ MOD_REG(PWMCONF, PWM_SYMMETRIC);	}
-void TMC2130Stepper::freewheel(		uint8_t B )	{ MOD_REG(PWMCONF, FREEWHEEL);		}
+void TMC2130Stepper::pwm_ampl(		uint8_t B )	{ TMC_MOD_REG(PWMCONF, PWM_AMPL);		}
+void TMC2130Stepper::pwm_grad(		uint8_t B )	{ TMC_MOD_REG(PWMCONF, PWM_GRAD);		}
+void TMC2130Stepper::pwm_freq(		uint8_t B )	{ TMC_MOD_REG(PWMCONF, PWM_FREQ);		}
+void TMC2130Stepper::pwm_autoscale(	bool 	B )	{ TMC_MOD_REG(PWMCONF, PWM_AUTOSCALE);	}
+void TMC2130Stepper::pwm_symmetric(	bool 	B )	{ TMC_MOD_REG(PWMCONF, PWM_SYMMETRIC);	}
+void TMC2130Stepper::freewheel(		uint8_t B )	{ TMC_MOD_REG(PWMCONF, FREEWHEEL);		}
 
-uint8_t TMC2130Stepper::pwm_ampl()		{ GET_BYTE(PWMCONF, PWM_AMPL);		}
-uint8_t TMC2130Stepper::pwm_grad()		{ GET_BYTE(PWMCONF, PWM_GRAD);		}
-uint8_t TMC2130Stepper::pwm_freq()		{ GET_BYTE(PWMCONF, PWM_FREQ);		}
-bool 	TMC2130Stepper::pwm_autoscale()	{ GET_BYTE(PWMCONF, PWM_AUTOSCALE);	}
-bool 	TMC2130Stepper::pwm_symmetric()	{ GET_BYTE(PWMCONF, PWM_SYMMETRIC);	}
-uint8_t TMC2130Stepper::freewheel()		{ GET_BYTE(PWMCONF, FREEWHEEL);		}
+uint8_t TMC2130Stepper::pwm_ampl()		{ TMC_GET_BYTE(PWMCONF, PWM_AMPL);		}
+uint8_t TMC2130Stepper::pwm_grad()		{ TMC_GET_BYTE(PWMCONF, PWM_GRAD);		}
+uint8_t TMC2130Stepper::pwm_freq()		{ TMC_GET_BYTE(PWMCONF, PWM_FREQ);		}
+bool 	TMC2130Stepper::pwm_autoscale()	{ TMC_GET_BYTE(PWMCONF, PWM_AUTOSCALE);	}
+bool 	TMC2130Stepper::pwm_symmetric()	{ TMC_GET_BYTE(PWMCONF, PWM_SYMMETRIC);	}
+uint8_t TMC2130Stepper::freewheel()		{ TMC_GET_BYTE(PWMCONF, FREEWHEEL);		}


### PR DESCRIPTION
When building for STM32 there is a name clashing between macros (`WRITE_REG`, `READ_REG `etc.) defined in the TMC2130 library and the  STM32 Arduino core. This PR will prefix macros in this library with `TMC_`.